### PR TITLE
SwiftPM iOS Target Version Downgraded to v12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "BottomSheet",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v12),
         .macCatalyst(.v13),
         .macOS(.v10_15)
     ],


### PR DESCRIPTION
SwiftPM のiOSターゲットバージョンを`v12`にダウングレードしました。